### PR TITLE
Fix filter check in Infinity connection

### DIFF
--- a/rag/utils/infinity_conn.py
+++ b/rag/utils/infinity_conn.py
@@ -416,7 +416,7 @@ class InfinityConnection(DocStoreConnection):
                                 matchExpr.method, matchExpr.topn, matchExpr.fusion_params
                             )
                 else:
-                    if len(filter_cond) > 0:
+                    if filter_cond:
                         builder.filter(filter_cond)
                 if orderBy.fields:
                     builder.sort(order_by_expr_list)


### PR DESCRIPTION
## Summary
- avoid `len` call on possible None filter condition in Infinity search logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_684e752bedb08332908a21fb0e16aa3e