### PR TITLE
Add special user page and layout

### DIFF
--- a/web/src/layouts/chat-only-header.tsx
+++ b/web/src/layouts/chat-only-header.tsx
@@ -1,0 +1,140 @@
+import { RAGFlowAvatar } from '@/components/ragflow-avatar';
+import { useTheme } from '@/components/theme-provider';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { Segmented, SegmentedValue } from '@/components/ui/segmented';
+import { LanguageList, LanguageMap } from '@/constants/common';
+import { useChangeLanguage } from '@/hooks/logic-hooks';
+import { useNavigatePage } from '@/hooks/logic-hooks/navigate-hooks';
+import { useNavigateWithFromState } from '@/hooks/route-hook';
+import { useFetchUserInfo, useListTenant } from '@/hooks/user-setting-hooks';
+import { TenantRole } from '@/pages/user-setting/constants';
+import { Routes } from '@/routes';
+import { camelCase } from 'lodash';
+import { ChevronDown, CircleHelp, MessageSquareText, Moon, Sun } from 'lucide-react';
+import React, { useCallback, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useLocation } from 'umi';
+
+const handleDocHelpCLick = () => {
+  window.open('https://ragflow.io/docs/dev/category/guides', 'target');
+};
+
+export function ChatOnlyHeader() {
+  const { t } = useTranslation();
+  const { pathname } = useLocation();
+  const navigate = useNavigateWithFromState();
+  const { navigateToProfile } = useNavigatePage();
+
+  const changeLanguage = useChangeLanguage();
+  const { setTheme, theme } = useTheme();
+
+  const {
+    data: { language = 'English', avatar, nickname },
+  } = useFetchUserInfo();
+
+  const handleItemClick = (key: string) => () => {
+    changeLanguage(key);
+  };
+
+  const { data } = useListTenant();
+
+  const showBell = useMemo(() => {
+    return data.some((x) => x.role === TenantRole.Invite);
+  }, [data]);
+
+  const items = LanguageList.map((x) => ({
+    key: x,
+    label: <span>{LanguageMap[x as keyof typeof LanguageMap]}</span>,
+  }));
+
+  const onThemeClick = React.useCallback(() => {
+    setTheme(theme === 'dark' ? 'light' : 'dark');
+  }, [setTheme, theme]);
+
+  const tagsData = useMemo(
+    () => [
+      { path: '/chat', name: t('header.chat'), icon: MessageSquareText },
+    ],
+    [t],
+  );
+
+  const options = useMemo(() => {
+    return tagsData.map((tag) => {
+      const HeaderIcon = tag.icon;
+
+      return {
+        label: <span>{tag.name}</span>,
+        value: tag.path,
+      };
+    });
+  }, [tagsData]);
+
+  const currentPath = useMemo(() => {
+    return tagsData.find((x) => pathname.startsWith(x.path))?.path || '/chat';
+  }, [pathname, tagsData]);
+
+  const handleChange = (path: SegmentedValue) => {
+    navigate(`${path}?simple=1` as Routes);
+  };
+
+  const handleLogoClick = useCallback(() => {
+    navigate(Routes.SimpleHome);
+  }, [navigate]);
+
+  return (
+    <section className="p-5 pr-14 flex justify-between items-center ">
+      <div className="flex items-center gap-4">
+        <img
+          src={'/logo.svg'}
+          alt="logo"
+          className="size-10 mr-[12]"
+          onClick={handleLogoClick}
+        />
+      </div>
+      <Segmented options={options} value={currentPath} onChange={handleChange} />
+      <div className="flex items-center gap-5 text-text-badge">
+        <DropdownMenu>
+          <DropdownMenuTrigger>
+            <div className="flex items-center gap-1">
+              {t(`common.${camelCase(language)}`)}
+              <ChevronDown className="size-4" />
+            </div>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent>
+            {items.map((x) => (
+              <DropdownMenuItem key={x.key} onClick={handleItemClick(x.key)}>
+                {x.label}
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+        <Button variant={'ghost'} onClick={handleDocHelpCLick}>
+          <CircleHelp />
+        </Button>
+        <Button variant={'ghost'} onClick={onThemeClick}>
+          {theme === 'light' ? <Sun /> : <Moon />}
+        </Button>
+        <div className="relative">
+          <RAGFlowAvatar
+            name={nickname}
+            avatar={avatar}
+            className="size-8 cursor-pointer"
+            onClick={navigateToProfile}
+          ></RAGFlowAvatar>
+          {showBell && (
+            <Badge className="h-5 w-8 absolute font-normal p-0 justify-center -right-8 -top-2 text-text-title-invert bg-gradient-to-l from-[#42D7E7] to-[#478AF5]">
+              Pro
+            </Badge>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/web/src/layouts/chat-only.tsx
+++ b/web/src/layouts/chat-only.tsx
@@ -1,0 +1,11 @@
+import { Outlet } from 'umi';
+import { ChatOnlyHeader } from './chat-only-header';
+
+export default function ChatOnlyLayout() {
+  return (
+    <section className="h-full flex flex-col text-colors-text-neutral-strong">
+      <ChatOnlyHeader></ChatOnlyHeader>
+      <Outlet />
+    </section>
+  );
+}

--- a/web/src/pages/chat/index.tsx
+++ b/web/src/pages/chat/index.tsx
@@ -45,11 +45,14 @@ import { useSetSelectedRecord } from '@/hooks/logic-hooks';
 import { IDialog } from '@/interfaces/database/chat';
 import { PictureInPicture2 } from 'lucide-react';
 import styles from './index.less';
+import { useSearchParams } from 'umi';
 
 const { Text } = Typography;
 
 const Chat = () => {
   const { data: dialogList, loading: dialogLoading } = useFetchNextDialogList();
+  const [searchParams] = useSearchParams();
+  const simpleMode = searchParams.get('simple') === '1';
   const { onRemoveDialog } = useDeleteDialog();
   const { onRemoveConversation } = useDeleteConversation();
   const { handleClickDialog } = useClickDialogCard();
@@ -235,9 +238,11 @@ const Chat = () => {
     <Flex className={styles.chatWrapper}>
       <Flex className={styles.chatAppWrapper}>
         <Flex flex={1} vertical>
-          <Button type="primary" onClick={handleShowChatConfigurationModal()}>
-            {t('createAssistant')}
-          </Button>
+          {!simpleMode && (
+            <Button type="primary" onClick={handleShowChatConfigurationModal()}>
+              {t('createAssistant')}
+            </Button>
+          )}
           <Divider></Divider>
           <Flex className={styles.chatAppContent} vertical gap={10}>
             <Spin spinning={dialogLoading} wrapperClassName={styles.chatSpin}>

--- a/web/src/pages/login/index.tsx
+++ b/web/src/pages/login/index.tsx
@@ -8,6 +8,8 @@ import {
 } from '@/hooks/login-hooks';
 import { useSystemConfig } from '@/hooks/system-hooks';
 import { rsaPsw } from '@/utils';
+import authorizationUtil from '@/utils/authorization-util';
+import { Routes } from '@/routes';
 import { Button, Checkbox, Form, Input } from 'antd';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -68,7 +70,12 @@ const Login = () => {
           password: rsaPassWord,
         });
         if (code === 0) {
-          navigate('/knowledge');
+          const { email } = authorizationUtil.getUserInfoObject() || {};
+          if (email === 'user2') {
+            navigate(Routes.SimpleHome);
+          } else {
+            navigate('/knowledge');
+          }
         }
       } else {
         const code = await register({

--- a/web/src/pages/simple/index.tsx
+++ b/web/src/pages/simple/index.tsx
@@ -1,0 +1,9 @@
+import { useEffect } from 'react';
+import { history } from 'umi';
+
+export default function SimpleHome() {
+  useEffect(() => {
+    history.replace('/chat?simple=1');
+  }, []);
+  return null;
+}

--- a/web/src/routes.ts
+++ b/web/src/routes.ts
@@ -21,6 +21,7 @@ export enum Routes {
   ParsedResult = `${Chunk}${Parsed}`,
   Result = '/result',
   ResultView = `${Chunk}${Result}`,
+  SimpleHome = '/simple',
 }
 
 const routes = [
@@ -317,6 +318,17 @@ const routes = [
       {
         path: `${Routes.ProfileSetting}/prompt`,
         component: `@/pages${Routes.ProfileSetting}/prompt`,
+      },
+    ],
+  },
+  {
+    path: Routes.SimpleHome,
+    layout: false,
+    component: '@/layouts/chat-only',
+    routes: [
+      {
+        path: Routes.SimpleHome,
+        component: `@/pages${Routes.SimpleHome}`,
       },
     ],
   },


### PR DESCRIPTION
## Summary
- introduce `SimpleHome` route and a new `ChatOnlyLayout`
- add a dedicated header with only a Chat tab
- hide the Create Assistant button when in `simple` mode
- redirect user `user2` to the new interface after login

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: umi not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e7a436c0483328ea726dab668f953